### PR TITLE
Fix missing workflow permissions

### DIFF
--- a/.github/workflows/pre-main.yml
+++ b/.github/workflows/pre-main.yml
@@ -7,6 +7,8 @@ on:
     branches: [main]
   workflow_dispatch:
 
+permissions: read-all
+
 jobs:
   lint:
     name: Lint Shell Scripts

--- a/.github/workflows/update-major-tag.yml
+++ b/.github/workflows/update-major-tag.yml
@@ -4,12 +4,13 @@ on:
   release:
     types: [published]
 
-permissions:
-  contents: write
+permissions: read-all
 
 jobs:
   update-major-tag:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v6


### PR DESCRIPTION
## Summary

- Add top-level `permissions: read-all` to all workflow files
- Move `contents: write` from top-level to job-level in `update-major-tag.yml`

This addresses the `actions/missing-workflow-permissions` code scanning alert by restricting default GITHUB_TOKEN permissions to read-only and granting write permissions only at the job level where needed.

## Related PRs

**Token Permissions:**
- palmsoftware/quick-k8s#93
- palmsoftware/quick-ocp#45
- redhat-best-practices-for-k8s/certsuite#3469
- redhat-best-practices-for-k8s/certsuite-qe#1371
- redhat-best-practices-for-k8s/certsuite-sample-workload#650
- redhat-best-practices-for-k8s/telco-bot#117
- redhat-best-practices-for-k8s/cnf-certsuite-operator#285
- redhat-best-practices-for-k8s/certsuite-probe#67
- redhat-best-practices-for-k8s/parser#100
- redhat-best-practices-for-k8s/certsuite-claim#163
- redhat-best-practices-for-k8s/perfdive#50
- redhat-best-practices-for-k8s/certsuite-overview#120
- redhat-best-practices-for-k8s/custom-catalog-builder#20
- redhat-best-practices-for-k8s/guide#27
- redhat-best-practices-for-k8s/kpi-collection-tool#67
- redhat-best-practices-for-k8s/certsuite-operator-plugin#10
- redhat-best-practices-for-k8s/certsuite-operator-plugin-teset#2

**Pinned Dependencies:**
- redhat-best-practices-for-k8s/certsuite#3470
- redhat-best-practices-for-k8s/certsuite-qe#1372
- redhat-best-practices-for-k8s/certsuite-sample-workload#651