### PR TITLE
Add macOS runner support for disk cleanup

### DIFF
--- a/.github/workflows/pre-main.yml
+++ b/.github/workflows/pre-main.yml
@@ -179,3 +179,36 @@ jobs:
         run: |
           docker pull alpine
           docker run --rm alpine echo "✅ Idempotency test passed"
+
+  test-macos:
+    name: Test macOS Cleanup
+    needs: lint
+    runs-on: macos-15
+    continue-on-error: true
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Initial disk usage
+        run: |
+          df -h
+          echo ""
+          echo "=== Xcode simulator runtimes ==="
+          xcrun simctl runtime list 2>/dev/null || echo "No simulator runtimes found"
+
+      - name: Test aggressive cleanup
+        uses: ./
+        with:
+          cleanup-mode: aggressive
+          remove-xcode-simulators: 'true'
+          remove-homebrew-cache: 'true'
+
+      - name: Verify cleanup
+        run: |
+          echo "=== Final disk usage ==="
+          df -h
+          echo ""
+          echo "=== Remaining simulator runtimes ==="
+          xcrun simctl runtime list 2>/dev/null || echo "No simulator runtimes found"
+          echo ""
+          echo "✅ macOS cleanup test completed"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Test Quick Cleanup](https://github.com/palmsoftware/quick-cleanup/actions/workflows/pre-main.yml/badge.svg)](https://github.com/palmsoftware/quick-cleanup/actions/workflows/pre-main.yml)
 
-Intelligent disk space optimization for GitHub Actions runners with automatic Docker relocation.
+Intelligent disk space optimization for GitHub Actions runners with automatic Docker relocation. Supports both Ubuntu and macOS runners.
 
 ## Why quick-cleanup?
 
@@ -76,6 +76,8 @@ This will:
 
 ### What Gets Cleaned
 
+#### Linux (Ubuntu)
+
 **Light mode**:
 - Package cache (apt-get clean, autoremove)
 - Snap packages (disabled revisions)
@@ -90,6 +92,23 @@ This will:
 - /usr/local/lib/node_modules (~1GB)
 - /opt/ghc, /usr/local/.ghcup (~2GB)
 - Large packages: MySQL, PostgreSQL, Firefox, Azure CLI, Google Cloud SDK
+
+#### macOS
+
+**Light mode**:
+- Homebrew cache cleanup
+- Android SDK (if present)
+- Docker image prune (if Docker is available)
+- Temporary files and log files
+
+**Aggressive mode** (everything above plus):
+- Xcode simulator runtimes (~5-15GB)
+- /usr/local/share/dotnet (.NET SDK)
+- /usr/local/share/powershell
+- /usr/local/share/chromium
+- /usr/local/lib/node_modules
+- /opt/ghc, /usr/local/.ghcup (Haskell)
+- System/library caches (~/Library/Caches, /Library/Caches)
 
 ## Use Cases
 
@@ -137,6 +156,17 @@ This will:
   uses: palmsoftware/quick-ocp@v0
 ```
 
+### macOS runner cleanup
+
+```yaml
+- name: Free space on macOS runner
+  uses: palmsoftware/quick-cleanup@v0
+  with:
+    cleanup-mode: aggressive
+    remove-xcode-simulators: 'true'
+    remove-homebrew-cache: 'true'
+```
+
 ## Configuration Reference
 
 ### Inputs
@@ -149,8 +179,10 @@ This will:
 | `minimum-free-space` | Required free space (GB) | `0` | Number (0 = no validation) |
 | `cleanup-threshold` | Threshold for auto mode (GB) | `20` | Number |
 | `remove-android` | Remove Android SDK | `true` | `true`, `false` |
-| `remove-large-packages` | Remove databases, browsers, CLIs | `true` | `true`, `false` |
+| `remove-large-packages` | Remove databases, browsers, CLIs (Linux only) | `true` | `true`, `false` |
 | `remove-docker-images` | Prune Docker images | `true` | `true`, `false` |
+| `remove-xcode-simulators` | Remove Xcode simulator runtimes (macOS only) | `true` | `true`, `false` |
+| `remove-homebrew-cache` | Clean Homebrew cache (macOS only) | `true` | `true`, `false` |
 
 ### Examples
 
@@ -201,13 +233,14 @@ Tested on ubuntu-22.04 runners:
 - ✅ Ubuntu 22.04 (fully tested)
 - ✅ Ubuntu 24.04 (fully tested)
 - ⚠️ Other Linux: May work, not tested
-- ❌ macOS: Not supported (different disk layout)
+- ⚠️ macOS 15 (experimental — cleanup only, no Docker relocation)
 - ❌ Windows: Not supported
 
 ## Limitations
 
-- **Ubuntu-only**: Relies on apt, systemd, standard GitHub Actions runner layout
-- **Root partition focus**: Optimized for standard runner disk layout (/, /mnt)
+- **Linux cleanup**: Relies on apt, systemd, standard GitHub Actions runner layout
+- **macOS cleanup**: Experimental; no Docker relocation (macOS runners don't use /mnt partitions)
+- **Root partition focus**: Optimized for standard runner disk layout (/, /mnt on Linux)
 - **No undo**: Cleanup is permanent, cannot restore removed packages
 - **Sudo required**: All operations require sudo access
 

--- a/action.yml
+++ b/action.yml
@@ -10,7 +10,7 @@ inputs:
     required: false
     default: 'auto'
   relocate-docker:
-    description: 'Move Docker storage to /mnt partition (always, auto, never)'
+    description: 'Move Docker storage to /mnt partition (always, auto, never) - Linux only'
     required: false
     default: 'auto'
   docker-storage-path:
@@ -30,20 +30,34 @@ inputs:
     required: false
     default: 'true'
   remove-large-packages:
-    description: 'Remove MySQL, PostgreSQL, Firefox, dotnet, etc.'
+    description: 'Remove MySQL, PostgreSQL, Firefox, dotnet, etc. (Linux only)'
     required: false
     default: 'true'
   remove-docker-images:
     description: 'Run docker system prune'
     required: false
     default: 'true'
+  remove-xcode-simulators:
+    description: 'Remove Xcode simulator runtimes (macOS only)'
+    required: false
+    default: 'true'
+  remove-homebrew-cache:
+    description: 'Clean Homebrew cache (macOS only)'
+    required: false
+    default: 'true'
 
 runs:
   using: 'composite'
   steps:
-    - name: Validate environment
+    - name: Validate environment (Linux)
+      if: runner.os == 'Linux'
       shell: bash
       run: ${{ github.action_path }}/scripts/validate-environment.sh
+
+    - name: Validate environment (macOS)
+      if: runner.os == 'macOS'
+      shell: bash
+      run: ${{ github.action_path }}/scripts/validate-environment-macos.sh
 
     - name: Initial disk report
       shell: bash
@@ -52,20 +66,26 @@ runs:
         df -h
         echo ""
         echo "=== System info ==="
-        echo "OS: $(lsb_release -d | cut -f2)"
-        echo "Memory: $(free -h | grep '^Mem:' | awk '{print $2}' | tr -d '\n') total"
-        echo "CPU cores: $(nproc)"
+        if [ "$(uname -s)" = "Darwin" ]; then
+          echo "OS: macOS $(sw_vers -productVersion)"
+          echo "Memory: $(( $(sysctl -n hw.memsize) / 1024 / 1024 / 1024 ))GB total"
+          echo "CPU cores: $(sysctl -n hw.ncpu)"
+        else
+          echo "OS: $(lsb_release -d | cut -f2)"
+          echo "Memory: $(free -h | grep '^Mem:' | awk '{print $2}' | tr -d '\n') total"
+          echo "CPU cores: $(nproc)"
+        fi
 
     - name: Relocate Docker storage
-      if: ${{ inputs.relocate-docker != 'never' }}
+      if: inputs.relocate-docker != 'never' && runner.os == 'Linux'
       shell: bash
       run: |
         ${{ github.action_path }}/scripts/relocate-docker.sh \
           "${{ inputs.relocate-docker }}" \
           "${{ inputs.docker-storage-path }}"
 
-    - name: Cleanup disk space
-      if: ${{ inputs.cleanup-mode != 'skip' }}
+    - name: Cleanup disk space (Linux)
+      if: inputs.cleanup-mode != 'skip' && runner.os == 'Linux'
       shell: bash
       run: |
         ${{ github.action_path }}/scripts/cleanup-disk.sh \
@@ -75,6 +95,19 @@ runs:
           "${{ inputs.remove-android }}" \
           "${{ inputs.remove-large-packages }}" \
           "${{ inputs.remove-docker-images }}"
+
+    - name: Cleanup disk space (macOS)
+      if: inputs.cleanup-mode != 'skip' && runner.os == 'macOS'
+      shell: bash
+      run: |
+        ${{ github.action_path }}/scripts/cleanup-disk-macos.sh \
+          "${{ inputs.cleanup-mode }}" \
+          "${{ inputs.cleanup-threshold }}" \
+          "${{ inputs.minimum-free-space }}" \
+          "${{ inputs.remove-android }}" \
+          "${{ inputs.remove-docker-images }}" \
+          "${{ inputs.remove-xcode-simulators }}" \
+          "${{ inputs.remove-homebrew-cache }}"
 
     - name: Final disk report
       shell: bash

--- a/scripts/cleanup-disk-macos.sh
+++ b/scripts/cleanup-disk-macos.sh
@@ -1,0 +1,249 @@
+#!/usr/bin/env bash
+# cleanup-disk-macos.sh - Intelligent disk space cleanup for macOS GitHub Actions runners
+#
+# Parameters:
+#   $1 - CLEANUP_MODE: auto, light, aggressive, or skip
+#   $2 - THRESHOLD_GB: threshold in GB for auto mode (default: 20)
+#   $3 - MINIMUM_FREE_GB: minimum required space in GB (default: 0 = no validation)
+#   $4 - REMOVE_ANDROID: true or false
+#   $5 - REMOVE_DOCKER_IMAGES: true or false
+#   $6 - REMOVE_XCODE_SIMULATORS: true or false
+#   $7 - REMOVE_HOMEBREW_CACHE: true or false
+
+# Note: Using best-effort approach - don't exit on cleanup failures
+# set -e
+
+CLEANUP_MODE="${1:-auto}"
+THRESHOLD_GB="${2:-20}"
+MINIMUM_FREE_GB="${3:-0}"
+REMOVE_ANDROID="${4:-true}"
+REMOVE_DOCKER_IMAGES="${5:-true}"
+REMOVE_XCODE_SIMULATORS="${6:-true}"
+REMOVE_HOMEBREW_CACHE="${7:-true}"
+
+# Start timing
+START_TIME=$(date +%s)
+
+echo "=============================================="
+echo "  DISK SPACE CLEANUP (macOS)"
+echo "=============================================="
+echo "Configuration:"
+echo "  Mode: $CLEANUP_MODE"
+echo "  Threshold: ${THRESHOLD_GB}GB"
+echo "  Minimum required: ${MINIMUM_FREE_GB}GB"
+echo "  Remove Android: $REMOVE_ANDROID"
+echo "  Remove Docker images: $REMOVE_DOCKER_IMAGES"
+echo "  Remove Xcode simulators: $REMOVE_XCODE_SIMULATORS"
+echo "  Remove Homebrew cache: $REMOVE_HOMEBREW_CACHE"
+echo ""
+
+# Skip if mode is 'skip'
+if [ "$CLEANUP_MODE" = "skip" ]; then
+  echo "Cleanup disabled (mode: skip). Skipping."
+  exit 0
+fi
+
+echo "=== Initial disk usage ==="
+df -h
+echo ""
+echo "=== Initial system info ==="
+echo "OS: macOS $(sw_vers -productVersion)"
+echo "Architecture: $(uname -m)"
+MEMORY_BYTES=$(sysctl -n hw.memsize)
+MEMORY_GB=$((MEMORY_BYTES / 1024 / 1024 / 1024))
+echo "Memory: ${MEMORY_GB}GB"
+echo "CPU: $(sysctl -n hw.ncpu) cores"
+
+# Check available space (use -k for consistent KB output on macOS)
+INITIAL_AVAILABLE_KB=$(df -k / | tail -1 | awk '{print $4}')
+INITIAL_AVAILABLE_GB=$((INITIAL_AVAILABLE_KB / 1024 / 1024))
+echo ""
+echo "Initial available space: ${INITIAL_AVAILABLE_GB}GB"
+
+# Determine cleanup intensity
+LIGHT_CLEANUP=0
+if [ "$CLEANUP_MODE" = "auto" ]; then
+  if [ "$INITIAL_AVAILABLE_GB" -gt "$THRESHOLD_GB" ]; then
+    echo "✅ Plenty of space available (>${THRESHOLD_GB}GB). Performing light cleanup."
+    LIGHT_CLEANUP=1
+  else
+    echo "⚠️  Limited space detected (<=${THRESHOLD_GB}GB). Performing aggressive cleanup."
+    LIGHT_CLEANUP=0
+  fi
+elif [ "$CLEANUP_MODE" = "light" ]; then
+  echo "Light cleanup mode selected."
+  LIGHT_CLEANUP=1
+elif [ "$CLEANUP_MODE" = "aggressive" ]; then
+  echo "Aggressive cleanup mode selected."
+  LIGHT_CLEANUP=0
+else
+  echo "❌ ERROR: Invalid cleanup mode: $CLEANUP_MODE"
+  echo "   Valid modes: auto, light, aggressive, skip"
+  exit 2
+fi
+
+# Homebrew cache cleanup
+if [ "$REMOVE_HOMEBREW_CACHE" = "true" ]; then
+  echo "=== Cleaning Homebrew cache ==="
+  if command -v brew >/dev/null 2>&1; then
+    brew cleanup -s 2>&1 || echo "⚠️  brew cleanup had some errors (non-critical)"
+    BREW_CACHE=$(brew --cache 2>/dev/null || echo "")
+    if [ -n "$BREW_CACHE" ] && [ -d "$BREW_CACHE" ]; then
+      echo "Removing Homebrew cache directory: $BREW_CACHE"
+      rm -rf "$BREW_CACHE" 2>&1 || echo "⚠️  Could not fully remove Homebrew cache"
+    fi
+    echo "✅ Homebrew cache cleaned"
+  else
+    echo "✅ Homebrew not available, skipping"
+  fi
+else
+  echo "=== Skipping Homebrew cache cleanup (disabled) ==="
+fi
+
+# Remove Android SDK if enabled
+if [ "$REMOVE_ANDROID" = "true" ]; then
+  echo "=== Checking for Android SDK ==="
+  ANDROID_DIRS="/usr/local/lib/android /opt/android ${ANDROID_HOME:-} ${ANDROID_SDK_ROOT:-}"
+  ANDROID_FOUND=0
+  for dir in $ANDROID_DIRS; do
+    if [ -d "$dir" ] && [ "$dir" != "" ]; then
+      echo "📱 Removing Android SDK: $dir"
+      sudo rm -rf "$dir" 2>&1 || echo "⚠️  Could not fully remove $dir"
+      ANDROID_FOUND=1
+    fi
+  done
+  if [ "$ANDROID_FOUND" -eq 0 ]; then
+    echo "✅ No Android SDK found to remove"
+  fi
+else
+  echo "=== Skipping Android SDK removal (disabled) ==="
+fi
+
+# Docker cleanup if enabled
+if [ "$REMOVE_DOCKER_IMAGES" = "true" ]; then
+  echo "=== Docker cleanup ==="
+  if command -v docker >/dev/null 2>&1; then
+    docker system prune -af --volumes 2>&1 || echo "⚠️  Docker cleanup had some errors (non-critical)"
+  else
+    echo "✅ Docker not available, skipping"
+  fi
+else
+  echo "=== Skipping Docker cleanup (disabled) ==="
+fi
+
+echo "=== Cleaning temporary files ==="
+sudo rm -rf /tmp/* 2>/dev/null || true
+sudo rm -rf /var/tmp/* 2>/dev/null || true
+
+echo "=== Cleaning log files ==="
+sudo rm -rf /var/log/*.log 2>/dev/null || true
+
+# Aggressive cleanup: remove large directories and Xcode simulators
+if [ "$LIGHT_CLEANUP" -eq 0 ]; then
+  # Xcode simulator cleanup
+  if [ "$REMOVE_XCODE_SIMULATORS" = "true" ]; then
+    echo "=== Removing Xcode simulator runtimes ==="
+    if command -v xcrun >/dev/null 2>&1; then
+      echo "Deleting all simulator devices..."
+      xcrun simctl delete all 2>&1 || echo "⚠️  Could not delete all simulator devices"
+      echo "Deleting all simulator runtimes..."
+      xcrun simctl runtime delete all 2>&1 || echo "⚠️  Could not delete all simulator runtimes"
+    fi
+    # Remove simulator runtime files directly
+    SIMULATOR_DIRS="/Library/Developer/CoreSimulator/Volumes /Library/Developer/CoreSimulator/Profiles/Runtimes"
+    for dir in $SIMULATOR_DIRS; do
+      if [ -d "$dir" ]; then
+        echo "🗂️  Removing: $dir"
+        sudo rm -rf "$dir" 2>&1 || echo "⚠️  Could not fully remove $dir"
+      fi
+    done
+    echo "✅ Xcode simulator cleanup complete"
+  else
+    echo "=== Skipping Xcode simulator removal (disabled) ==="
+  fi
+
+  echo "=== Removing other large directories ==="
+  LARGE_DIRS="/usr/local/share/dotnet /usr/local/share/powershell /usr/local/share/chromium /usr/local/lib/node_modules /opt/ghc /usr/local/.ghcup"
+  for dir in $LARGE_DIRS; do
+    if [ -d "$dir" ]; then
+      echo "🗂️  Removing: $dir"
+      sudo rm -rf "$dir" 2>&1 || echo "⚠️  Could not fully remove $dir"
+    fi
+  done
+
+  echo "=== Cleaning system caches ==="
+  if [ -d "$HOME/Library/Caches" ]; then
+    echo "Cleaning user library caches..."
+    rm -rf "${HOME:?}/Library/Caches/"* 2>/dev/null || true
+  fi
+  if [ -d "/Library/Caches" ]; then
+    echo "Cleaning system library caches..."
+    sudo rm -rf /Library/Caches/* 2>/dev/null || true
+  fi
+else
+  echo "=== Skipping large directory cleanup (light mode) ==="
+  # Still clean Xcode simulators in light mode if explicitly requested
+  if [ "$REMOVE_XCODE_SIMULATORS" = "true" ]; then
+    echo "=== Removing Xcode simulator runtimes (explicitly enabled) ==="
+    if command -v xcrun >/dev/null 2>&1; then
+      echo "Deleting all simulator devices..."
+      xcrun simctl delete all 2>&1 || echo "⚠️  Could not delete all simulator devices"
+      echo "Deleting all simulator runtimes..."
+      xcrun simctl runtime delete all 2>&1 || echo "⚠️  Could not delete all simulator runtimes"
+    fi
+    SIMULATOR_DIRS="/Library/Developer/CoreSimulator/Volumes /Library/Developer/CoreSimulator/Profiles/Runtimes"
+    for dir in $SIMULATOR_DIRS; do
+      if [ -d "$dir" ]; then
+        echo "🗂️  Removing: $dir"
+        sudo rm -rf "$dir" 2>&1 || echo "⚠️  Could not fully remove $dir"
+      fi
+    done
+    echo "✅ Xcode simulator cleanup complete"
+  fi
+fi
+
+echo "=== Cleanup Summary ==="
+df -h
+
+# Calculate space freed (use -k for consistent KB output)
+FINAL_AVAILABLE_KB=$(df -k / | tail -1 | awk '{print $4}')
+FINAL_AVAILABLE_GB=$((FINAL_AVAILABLE_KB / 1024 / 1024))
+SPACE_FREED_GB=$((FINAL_AVAILABLE_GB - INITIAL_AVAILABLE_GB))
+
+# Calculate cleanup duration
+END_TIME=$(date +%s)
+DURATION=$((END_TIME - START_TIME))
+
+echo ""
+echo "📊 DISK SPACE ANALYSIS"
+echo "├─ Initial space: ${INITIAL_AVAILABLE_GB}GB"
+echo "├─ Final space: ${FINAL_AVAILABLE_GB}GB"
+echo "├─ Space freed: ${SPACE_FREED_GB}GB"
+echo "├─ Cleanup duration: ${DURATION}s"
+echo "└─ Root partition: $(df -h / | tail -1 | awk '{print $4}') free"
+
+# Validate minimum space requirement
+echo ""
+if [ "$MINIMUM_FREE_GB" -gt 0 ]; then
+  echo "=== Validating minimum space requirement ==="
+  # Re-enable strict error handling for final validation
+  set -e
+  if [ "$FINAL_AVAILABLE_GB" -lt "$MINIMUM_FREE_GB" ]; then
+    echo "❌ ERROR: Insufficient disk space (${FINAL_AVAILABLE_GB}GB)."
+    echo "   Required: ${MINIMUM_FREE_GB}GB"
+    echo "   Suggestion: Try cleanup-mode: aggressive or reduce minimum-free-space requirement"
+    echo ""
+    echo "Available space breakdown:"
+    df -h
+    exit 1
+  fi
+  echo "✅ Sufficient disk space available (${FINAL_AVAILABLE_GB}GB >= ${MINIMUM_FREE_GB}GB required)"
+else
+  echo "=== Skipping space validation (minimum-free-space: 0) ==="
+fi
+
+echo ""
+echo "=============================================="
+echo "✅ DISK CLEANUP COMPLETED SUCCESSFULLY"
+echo "=============================================="
+exit 0

--- a/scripts/cleanup-disk-macos.sh
+++ b/scripts/cleanup-disk-macos.sh
@@ -138,26 +138,43 @@ sudo rm -rf /var/tmp/* 2>/dev/null || true
 echo "=== Cleaning log files ==="
 sudo rm -rf /var/log/*.log 2>/dev/null || true
 
+# Function to clean up Xcode simulator runtimes
+cleanup_xcode_simulators() {
+  echo "=== Removing Xcode simulator runtimes ==="
+  if command -v xcrun >/dev/null 2>&1; then
+    echo "Shutting down all simulators..."
+    xcrun simctl shutdown all 2>&1 || true
+    echo "Deleting all simulator devices..."
+    xcrun simctl delete all 2>&1 || echo "⚠️  Could not delete all simulator devices"
+    echo "Deleting all simulator runtimes..."
+    xcrun simctl runtime delete all 2>&1 || echo "⚠️  Could not delete all simulator runtimes"
+  fi
+
+  # Unmount any simulator disk images still mounted under CoreSimulator/Volumes
+  if [ -d "/Library/Developer/CoreSimulator/Volumes" ]; then
+    echo "Unmounting simulator disk images..."
+    mount | grep "/Library/Developer/CoreSimulator/Volumes" | awk '{print $3}' | while read -r mountpoint; do
+      echo "  Detaching: $mountpoint"
+      sudo hdiutil detach "$mountpoint" -force 2>&1 || true
+    done
+  fi
+
+  # Now safe to remove the directories
+  SIMULATOR_DIRS="/Library/Developer/CoreSimulator/Volumes /Library/Developer/CoreSimulator/Profiles/Runtimes"
+  for dir in $SIMULATOR_DIRS; do
+    if [ -d "$dir" ]; then
+      echo "🗂️  Removing: $dir"
+      sudo rm -rf "$dir" 2>&1 || echo "⚠️  Could not fully remove $dir"
+    fi
+  done
+  echo "✅ Xcode simulator cleanup complete"
+}
+
 # Aggressive cleanup: remove large directories and Xcode simulators
 if [ "$LIGHT_CLEANUP" -eq 0 ]; then
   # Xcode simulator cleanup
   if [ "$REMOVE_XCODE_SIMULATORS" = "true" ]; then
-    echo "=== Removing Xcode simulator runtimes ==="
-    if command -v xcrun >/dev/null 2>&1; then
-      echo "Deleting all simulator devices..."
-      xcrun simctl delete all 2>&1 || echo "⚠️  Could not delete all simulator devices"
-      echo "Deleting all simulator runtimes..."
-      xcrun simctl runtime delete all 2>&1 || echo "⚠️  Could not delete all simulator runtimes"
-    fi
-    # Remove simulator runtime files directly
-    SIMULATOR_DIRS="/Library/Developer/CoreSimulator/Volumes /Library/Developer/CoreSimulator/Profiles/Runtimes"
-    for dir in $SIMULATOR_DIRS; do
-      if [ -d "$dir" ]; then
-        echo "🗂️  Removing: $dir"
-        sudo rm -rf "$dir" 2>&1 || echo "⚠️  Could not fully remove $dir"
-      fi
-    done
-    echo "✅ Xcode simulator cleanup complete"
+    cleanup_xcode_simulators
   else
     echo "=== Skipping Xcode simulator removal (disabled) ==="
   fi
@@ -184,21 +201,7 @@ else
   echo "=== Skipping large directory cleanup (light mode) ==="
   # Still clean Xcode simulators in light mode if explicitly requested
   if [ "$REMOVE_XCODE_SIMULATORS" = "true" ]; then
-    echo "=== Removing Xcode simulator runtimes (explicitly enabled) ==="
-    if command -v xcrun >/dev/null 2>&1; then
-      echo "Deleting all simulator devices..."
-      xcrun simctl delete all 2>&1 || echo "⚠️  Could not delete all simulator devices"
-      echo "Deleting all simulator runtimes..."
-      xcrun simctl runtime delete all 2>&1 || echo "⚠️  Could not delete all simulator runtimes"
-    fi
-    SIMULATOR_DIRS="/Library/Developer/CoreSimulator/Volumes /Library/Developer/CoreSimulator/Profiles/Runtimes"
-    for dir in $SIMULATOR_DIRS; do
-      if [ -d "$dir" ]; then
-        echo "🗂️  Removing: $dir"
-        sudo rm -rf "$dir" 2>&1 || echo "⚠️  Could not fully remove $dir"
-      fi
-    done
-    echo "✅ Xcode simulator cleanup complete"
+    cleanup_xcode_simulators
   fi
 fi
 

--- a/scripts/validate-environment-macos.sh
+++ b/scripts/validate-environment-macos.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# validate-environment-macos.sh - Pre-flight environment validation for quick-cleanup on macOS
+
+set -e
+
+echo "=== Validating environment for quick-cleanup (macOS) ==="
+
+# Check OS compatibility
+echo "Checking OS compatibility..."
+if [ "$(uname -s)" != "Darwin" ]; then
+  echo "❌ ERROR: This script requires macOS (Darwin)."
+  exit 1
+fi
+
+OS_VERSION=$(sw_vers -productVersion)
+echo "✅ OS: macOS $OS_VERSION"
+
+# Check required tools
+echo ""
+echo "Checking required tools..."
+MISSING_TOOLS=()
+
+if ! command -v jq &> /dev/null; then
+  MISSING_TOOLS+=("jq")
+fi
+
+if ! command -v sudo &> /dev/null; then
+  MISSING_TOOLS+=("sudo")
+fi
+
+if [ ${#MISSING_TOOLS[@]} -gt 0 ]; then
+  echo "❌ ERROR: Missing required tools: ${MISSING_TOOLS[*]}"
+  echo "   Please install the missing tools before running quick-cleanup."
+  exit 1
+fi
+echo "✅ Required tools found (jq, sudo)"
+
+# Check optional tools
+echo ""
+echo "Checking optional tools..."
+if command -v docker &> /dev/null; then
+  echo "✅ Docker is available"
+else
+  echo "ℹ️  Docker not found (optional on macOS)"
+fi
+
+if command -v brew &> /dev/null; then
+  echo "✅ Homebrew is available"
+else
+  echo "ℹ️  Homebrew not found"
+fi
+
+if command -v xcrun &> /dev/null; then
+  echo "✅ Xcode command-line tools available"
+else
+  echo "ℹ️  Xcode command-line tools not found"
+fi
+
+# Check sudo access
+echo ""
+echo "Checking sudo access..."
+if ! sudo -n true 2>/dev/null; then
+  echo "⚠️  WARNING: sudo requires password. This may cause issues in GitHub Actions."
+else
+  echo "✅ sudo access available"
+fi
+
+# Analyze disk layout
+echo ""
+echo "Analyzing disk layout..."
+
+if ! df / &> /dev/null; then
+  echo "❌ ERROR: Cannot access root partition"
+  exit 1
+fi
+
+ROOT_AVAILABLE_KB=$(df -k / | tail -1 | awk '{print $4}')
+ROOT_AVAILABLE_GB=$((ROOT_AVAILABLE_KB / 1024 / 1024))
+echo "  Root partition (/): ${ROOT_AVAILABLE_GB}GB available"
+
+# Detect GitHub Actions environment
+echo ""
+if [ -n "$GITHUB_ACTIONS" ]; then
+  echo "✅ GitHub Actions environment detected"
+  echo "  Runner OS: ${RUNNER_OS:-unknown}"
+  echo "  Runner Arch: ${RUNNER_ARCH:-unknown}"
+else
+  echo "⚠️  Not running in GitHub Actions environment"
+  echo "   This action is designed for GitHub Actions runners"
+fi
+
+# System information
+echo ""
+echo "=== System Information ==="
+echo "OS: macOS $OS_VERSION"
+echo "Architecture: $(uname -m)"
+echo "Kernel: $(uname -r)"
+MEMORY_BYTES=$(sysctl -n hw.memsize)
+MEMORY_GB=$((MEMORY_BYTES / 1024 / 1024 / 1024))
+echo "Memory: ${MEMORY_GB}GB total"
+echo "CPU cores: $(sysctl -n hw.ncpu)"
+echo "Disk layout:"
+df -h | grep -E '^(Filesystem|/dev/)' || df -h
+
+echo ""
+echo "✅ Environment validation complete"


### PR DESCRIPTION
## Summary

- Add dedicated macOS cleanup scripts targeting Xcode simulator runtimes (5-15GB), Homebrew cache, .NET SDK, system caches, and other bloat
- OS-based dispatching in `action.yml` — Linux scripts remain completely untouched, Docker relocation automatically skipped on macOS
- Two new inputs: `remove-xcode-simulators` and `remove-homebrew-cache` (macOS only, default `true`)
- CI workflow adds `test-macos` job on `macos-15` with `continue-on-error: true` for experimental validation

## Test plan

- [ ] Existing Linux CI jobs pass with no regressions (scripts untouched)
- [ ] New `test-macos` job runs on macos-15 and reports space freed
- [ ] Xcode simulator runtimes are removed in aggressive mode
- [ ] Shellcheck passes on all scripts (`make lint`)