### PR TITLE
Remove unused jq requirement from macOS validation

### DIFF
--- a/scripts/validate-environment-macos.sh
+++ b/scripts/validate-environment-macos.sh
@@ -18,22 +18,13 @@ echo "✅ OS: macOS $OS_VERSION"
 # Check required tools
 echo ""
 echo "Checking required tools..."
-MISSING_TOOLS=()
-
-if ! command -v jq &> /dev/null; then
-  MISSING_TOOLS+=("jq")
-fi
 
 if ! command -v sudo &> /dev/null; then
-  MISSING_TOOLS+=("sudo")
-fi
-
-if [ ${#MISSING_TOOLS[@]} -gt 0 ]; then
-  echo "❌ ERROR: Missing required tools: ${MISSING_TOOLS[*]}"
-  echo "   Please install the missing tools before running quick-cleanup."
+  echo "❌ ERROR: Missing required tool: sudo"
+  echo "   Please install sudo before running quick-cleanup."
   exit 1
 fi
-echo "✅ Required tools found (jq, sudo)"
+echo "✅ Required tools found (sudo)"
 
 # Check optional tools
 echo ""


### PR DESCRIPTION
## Summary

- Remove `jq` from the required tools check in `validate-environment-macos.sh` — it is not used by any macOS code path and would unnecessarily block the action on runners without it installed

## Test plan

- [ ] Verify `pre-main.yml` macOS test job passes without jq being required
- [ ] Confirm no macOS scripts reference jq