### PR TITLE
feat: add ubuntu-26.04 to CI test matrix

### DIFF
--- a/.github/workflows/pre-main.yml
+++ b/.github/workflows/pre-main.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-22.04, ubuntu-24.04]
+        os: [ubuntu-22.04, ubuntu-24.04, ubuntu-26.04]
     steps:
       - name: Checkout
         uses: actions/checkout@v6


### PR DESCRIPTION
## Summary

- Adds ubuntu-26.04 to the test-auto-mode job OS matrix in pre-main.yml
- Other jobs (light, aggressive, skip, custom, idempotency) remain pinned to ubuntu-22.04 since they test specific functionality rather than OS compatibility

## Test plan

- [ ] CI passes on all three matrix entries: ubuntu-22.04, ubuntu-24.04, ubuntu-26.04
- [ ] Existing pinned jobs continue to pass unchanged